### PR TITLE
add npm versioning badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm](https://img.shields.io/npm/v/@internetarchive/dweb-mirror.svg)](npm.im/@internetarchive/dweb-mirror)
+
 # Offline Internet Archive README 
 
 


### PR DESCRIPTION
related to discuss in #259 

for me it was no easy to see versioning (github releases are empty) and in the readme I could not find a clear part linking that github repo with the npm one

but in the other side npm points go github clearly https://www.npmjs.com/package/@internetarchive/dweb-mirror