### PR TITLE
fix stopServer and allow a shutdown if completed

### DIFF
--- a/internetarchive
+++ b/internetarchive
@@ -276,8 +276,11 @@ function stopServer(cb) {
             cb(null); // Dont pass on failure, still want to stop transports
         });
         server = undefined; // Its obviously not running
+    } else {
+        cb(null);
     }
 }
+
 waterfall([
     cb => MirrorConfig.new(undefined,
         (obj) => { if (typeof obj.directories !== "undefined") MirrorFS.setState({directories: obj.directories}) },
@@ -306,6 +309,10 @@ waterfall([
     if (err) {
         debug("Failed: %s", err.message)
     } else {
-        debug('Completed' + ((!!server) ? " but server still running" : ""));
+        if (server) {
+            debug('Completed, but server still running');
+        } else {
+            debug('Completed');
+        }
     }
 });


### PR DESCRIPTION
I tried running the process (probably without proper configuration) and noticed it got stuck in the stopServer because the callback is never called when the server isn't started.

This is mainly to see if you're accepting PRs for this project. I'm thinking about getting pretty involved with it. If I'm going to start working with it, I thought I should try to see if I can contribute back. Although I'm not sure the most effective way to approach this and coordinate things.

I see you have node 12 in the dockerfile. I think this project could get a lot more support if it was more modernized, especially with handling async behavior (which currently impedes readability imo). I'm planning on making things more readable and adding type definitions for improved intellisense, as well as fixing bugs.

Anyway, I think this project is a fantastic idea and I hope I'll be able to contribute!