### PR TITLE
Update installation scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@ set -e # Break on error
 #set -x # Lets see whats happening
 
 function step {
+  # output the step the process is at
   STEPALL=$*
   STEPNUMBER=$1
   shift
@@ -26,6 +27,7 @@ function step {
 }
 
 function install_pkg() {
+  # install a package properly for the current operating system
   step XXX "Installing $*"
   if [ "${OPERATINGSYSTEM}" != "darwin" ]
   then
@@ -36,6 +38,7 @@ function install_pkg() {
 }
 
 function check_cmd() {
+  # silence a command, but preserve its exit status
   "$@" >/dev/null 2>&1
 }
 
@@ -127,8 +130,9 @@ then
   install_pkg libsecret-1-dev || echo "Libsecret failed to install, but that is ok"
   check_cmd netstat --version || install_pkg net-tools # Make debugging so much easier
 else # Its darwin (Mac OSX)
-  step XXX "Installing wget nodejs yarn"
+  # TODO: change a couple lines below to use only curl or only wget, rather than both, as each one performs the same task as the other
   check_cmd curl --version || install_pkg curl
+  check_cmd wget --version || install_pkg wget
   # The brew installer for node is broken (fails to run the npx line in bookreader/package.json), use the line below as found on https://nodejs.org/en/download/package-manager/#macos
   #node --version >>/dev/null || brew install nodejs
   check_cmd node --version || ( curl "https://nodejs.org/dist/latest/node-${VERSION:-$(wget -qO- https://nodejs.org/dist/latest-v12.x/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')}.pkg" > "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/" )

--- a/install_dev.sh
+++ b/install_dev.sh
@@ -22,6 +22,7 @@ REPOS="dweb-transports dweb-archivecontroller epubjs-reader bookreader dweb-arch
 # Note that dweb-transport and dweb-gatewahy are not installed they are only useful when running as a gateway server at the archive.
 
 function step {
+  # output the step the process is at
   STEPALL=$*
   STEPNUMBER=$1
   shift
@@ -32,6 +33,7 @@ function step {
 }
 
 function install_pkg() {
+  # install a package properly for the current operating system
   step XXX "Installing $*"
   if [ "${OPERATINGSYSTEM}" != "darwin" ]
   then
@@ -42,6 +44,7 @@ function install_pkg() {
 }
 
 function check_cmd() {
+  # silence a command, but preserve its exit status
   "$@" >/dev/null 2>&1
 }
 
@@ -126,7 +129,9 @@ then
   install_pkg libsecret-1-dev || echo "Libsecret failed to install, but that is ok"
   check_cmd netstat --version || install_pkg net-tools # Make debugging so much easier
 else
+  # TODO: change a couple lines below to use only curl or only wget, rather than both, as each one performs the same task as the other
   check_cmd curl --version || install_pkg curl
+  check_cmd wget --version || install_pkg wget
   # The brew installer for node is broken (fails to run the npx line in bookreader/package.json), use the line below as found on https://nodejs.org/en/download/package-manager/#macos
   #check_cmd node --version || install_pkg nodejs
   check_cmd node --version || ( curl "https://nodejs.org/dist/latest/node-${VERSION:-$(wget -qO- https://nodejs.org/dist/latest/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')}.pkg" > "$HOME/Downloads/node-latest.pkg" && sudo installer -store -pkg "$HOME/Downloads/node-latest.pkg" -target "/" )


### PR DESCRIPTION
I can now install using either script on my redhat system, even though redhat isn't supported yet.

- added check_cmd and install_pkg commands, to make it easy for users to manually install packages, and easy for maintainers to add new packaging systems
- normalised a few differences between the two scripts
- repaired the clone of epubjs which was broken due to a typo
- guard webpack and grunt runs with yarn so they don't need to be manually installed
- fix darwin download of wget to instead download curl, which is the tool actually used